### PR TITLE
Add flag mode feature

### DIFF
--- a/src/components/GameInfo.module.scss
+++ b/src/components/GameInfo.module.scss
@@ -118,6 +118,32 @@
   }
 }
 
+.flagModeButton {
+  padding: 0.375rem 0.75rem;
+  border-radius: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  transition: all 0.2s ease;
+  border: 1px solid #4b5563;
+
+  &.active {
+    background-color: #dc2626;
+    color: white;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    transform: scale(1.05);
+  }
+
+  &.inactive {
+    background-color: #1f2937;
+    color: #d1d5db;
+
+    &:hover {
+      background-color: #374151;
+      border-color: #6b7280;
+    }
+  }
+}
+
 .resetButton {
   padding: 0.375rem 1rem;
   background: linear-gradient(to right, #16a34a, #15803d);

--- a/src/components/GameInfo.tsx
+++ b/src/components/GameInfo.tsx
@@ -10,8 +10,10 @@ interface GameInfoProps {
   difficulty: GameDifficulty;
   boardWidth: number;
   boardHeight: number;
+  isFlagMode: boolean;
   onDifficultyChange: (difficulty: GameDifficulty) => void;
   onReset: () => void;
+  onToggleFlagMode: () => void;
 }
 
 export default function GameInfo({
@@ -21,8 +23,10 @@ export default function GameInfo({
   difficulty,
   boardWidth,
   boardHeight,
+  isFlagMode,
   onDifficultyChange,
   onReset,
+  onToggleFlagMode,
 }: GameInfoProps) {
   const getStatusMessage = () => {
     switch (gameStatus) {
@@ -108,6 +112,15 @@ export default function GameInfo({
               上級
             </button>
           </div>
+          
+          <button
+            onClick={onToggleFlagMode}
+            className={`${styles.flagModeButton} ${
+              isFlagMode ? styles.active : styles.inactive
+            }`}
+          >
+            🚩 旗立モード
+          </button>
           
           <button
             onClick={onReset}

--- a/src/components/Minesweeper.module.scss
+++ b/src/components/Minesweeper.module.scss
@@ -74,3 +74,9 @@
   color: #9ca3af;
   font-size: 0.875rem;
 }
+
+.flagModeHint {
+  margin-top: 0.5rem;
+  color: #f87171;
+  font-weight: 500;
+}

--- a/src/components/Minesweeper.tsx
+++ b/src/components/Minesweeper.tsx
@@ -10,6 +10,7 @@ export default function Minesweeper() {
     gameState,
     difficulty,
     resetGame,
+    toggleFlagMode,
     handleCellClick,
     handleCellRightClick,
   } = useMinesweeper();
@@ -42,8 +43,10 @@ export default function Minesweeper() {
             difficulty={difficulty}
             boardWidth={gameState.width}
             boardHeight={gameState.height}
+            isFlagMode={gameState.isFlagMode}
             onDifficultyChange={handleDifficultyChange}
             onReset={handleReset}
+            onToggleFlagMode={toggleFlagMode}
           />
         </div>
       </div>
@@ -62,6 +65,9 @@ export default function Minesweeper() {
 
           <div className={styles.footer}>
             <p>💡 ヒント: 数字は周囲の地雷の数を示しています</p>
+            {gameState.isFlagMode && (
+              <p className={styles.flagModeHint}>🚩 旗立モード: 左クリックでフラグを立てます</p>
+            )}
           </div>
         </div>
       </div>

--- a/src/hooks/useMinesweeper.ts
+++ b/src/hooks/useMinesweeper.ts
@@ -26,6 +26,7 @@ export function useMinesweeper() {
       revealedCount: 0,
       gameStatus: 'playing',
       isFirstClick: true,
+      isFlagMode: false,
     };
   });
 
@@ -42,6 +43,7 @@ export function useMinesweeper() {
       revealedCount: 0,
       gameStatus: 'playing',
       isFirstClick: true,
+      isFlagMode: false,
     });
     
     if (newDifficulty) {
@@ -49,11 +51,29 @@ export function useMinesweeper() {
     }
   }, [difficulty]);
 
+  const toggleFlagMode = useCallback(() => {
+    setGameState(prevState => ({
+      ...prevState,
+      isFlagMode: !prevState.isFlagMode,
+    }));
+  }, []);
+
   const handleCellClick = useCallback((x: number, y: number) => {
     if (gameState.gameStatus !== 'playing') return;
 
     setGameState(prevState => {
       let newCells = [...prevState.cells];
+
+      // 旗立モードの場合、フラグを切り替える
+      if (prevState.isFlagMode) {
+        newCells = toggleFlag(newCells, x, y);
+        const stats = getGameStats(newCells);
+        return {
+          ...prevState,
+          cells: newCells,
+          flaggedCount: stats.flaggedCount,
+        };
+      }
 
       // 最初のクリックの場合、地雷を配置
       if (prevState.isFirstClick) {
@@ -83,7 +103,7 @@ export function useMinesweeper() {
         flaggedCount: stats.flaggedCount,
       };
     });
-  }, [gameState.gameStatus, gameState.isFirstClick, gameState.mineCount]);
+  }, [gameState.gameStatus, gameState.isFirstClick, gameState.mineCount, gameState.isFlagMode]);
 
   const handleCellRightClick = useCallback((x: number, y: number) => {
     if (gameState.gameStatus !== 'playing') return;
@@ -104,6 +124,7 @@ export function useMinesweeper() {
     gameState,
     difficulty,
     resetGame,
+    toggleFlagMode,
     handleCellClick,
     handleCellRightClick,
   };

--- a/src/types/minesweeper.ts
+++ b/src/types/minesweeper.ts
@@ -21,6 +21,7 @@ export interface GameState {
   revealedCount: number;
   gameStatus: 'playing' | 'won' | 'lost';
   isFirstClick: boolean;
+  isFlagMode: boolean;
 }
 
 export type GameDifficulty = 'easy' | 'medium' | 'hard';


### PR DESCRIPTION
## 機能追加: 旗立モード

### 🚩 新機能
- **旗立モードトグル**: メニューに旗立モードの切り替えボタンを追加
- **左クリックでフラグ**: 旗立モード中は左クリックでフラグを立てる
- **視覚的フィードバック**: 旗立モード中はボタンが赤色でハイライト
- **ヒント表示**: 旗立モード中は画面下部にヒントを表示

### 🔧 技術的な変更
- **型定義の拡張**: にプロパティを追加
- **フックの拡張**: に関数を追加
- **UIコンポーネント**: 旗立モードボタンとヒント表示を追加
- **スタイリング**: 旗立モード用のSassスタイルを追加

### 🎮 使用方法
1. メニューの「🚩 旗立モード」ボタンをクリック
2. ボタンが赤色になったら旗立モードが有効
3. 左クリックでフラグを立てる
4. 再度ボタンをクリックで通常モードに戻る

### 📱 ユーザー体験の向上
- **直感的な操作**: 旗立モード中は左クリックでフラグ操作
- **視覚的フィードバック**: モードの状態が一目で分かる
- **従来の操作も維持**: 右クリックでのフラグ操作も引き続き可能