### PR TITLE
Remove hint text about numbers

### DIFF
--- a/src/components/Minesweeper.tsx
+++ b/src/components/Minesweeper.tsx
@@ -64,7 +64,6 @@ export default function Minesweeper() {
           </div>
 
           <div className={styles.footer}>
-            <p>💡 ヒント: 数字は周囲の地雷の数を示しています</p>
             {gameState.isFlagMode && (
               <p className={styles.flagModeHint}>🚩 旗立モード: 左クリックでフラグを立てます</p>
             )}

--- a/src/components/__tests__/Minesweeper.test.tsx
+++ b/src/components/__tests__/Minesweeper.test.tsx
@@ -1,0 +1,118 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Minesweeper from '../Minesweeper'
+
+// Mock the CSS module
+jest.mock('../Minesweeper.module.scss', () => ({
+  container: 'container',
+  header: 'header',
+  headerContent: 'headerContent',
+  title: 'title',
+  subtitle: 'subtitle',
+  menuContainer: 'menuContainer',
+  menuContent: 'menuContent',
+  mainContent: 'mainContent',
+  content: 'content',
+  gameBoardContainer: 'gameBoardContainer',
+  footer: 'footer',
+  flagModeHint: 'flagModeHint',
+}))
+
+// Mock the GameBoard component
+jest.mock('../GameBoard', () => {
+  return function MockGameBoard() {
+    return <div data-testid="game-board">Game Board</div>
+  }
+})
+
+// Mock the GameInfo component
+jest.mock('../GameInfo', () => {
+  return function MockGameInfo() {
+    return <div data-testid="game-info">Game Info</div>
+  }
+})
+
+// Mock the useMinesweeper hook
+jest.mock('@/hooks/useMinesweeper', () => ({
+  useMinesweeper: () => ({
+    gameState: {
+      cells: [],
+      width: 9,
+      height: 9,
+      mineCount: 10,
+      flaggedCount: 0,
+      revealedCount: 0,
+      gameStatus: 'playing',
+      isFirstClick: true,
+      isFlagMode: false,
+    },
+    difficulty: 'easy',
+    resetGame: jest.fn(),
+    toggleFlagMode: jest.fn(),
+    handleCellClick: jest.fn(),
+    handleCellRightClick: jest.fn(),
+  }),
+}))
+
+describe('Minesweeper Component', () => {
+  it('renders the game title', () => {
+    render(<Minesweeper />)
+    
+    expect(screen.getByText('マインスイーパー')).toBeInTheDocument()
+  })
+
+  it('renders the game subtitle', () => {
+    render(<Minesweeper />)
+    
+    expect(screen.getByText('左クリックでセルを開く、右クリックでフラグを立てる')).toBeInTheDocument()
+  })
+
+  it('renders game board and game info components', () => {
+    render(<Minesweeper />)
+    
+    expect(screen.getByTestId('game-board')).toBeInTheDocument()
+    expect(screen.getByTestId('game-info')).toBeInTheDocument()
+  })
+
+  it('does not render hint text about numbers', () => {
+    render(<Minesweeper />)
+    
+    // ヒントテキストが表示されないことを確認
+    expect(screen.queryByText('💡 ヒント: 数字は周囲の地雷の数を示しています')).not.toBeInTheDocument()
+  })
+
+  it('does not render flag mode hint when flag mode is disabled', () => {
+    render(<Minesweeper />)
+    
+    // 旗立モードのヒントが表示されないことを確認
+    expect(screen.queryByText('🚩 旗立モード: 左クリックでフラグを立てます')).not.toBeInTheDocument()
+  })
+
+  it('renders flag mode hint when flag mode is enabled', () => {
+    // Mock the hook to return flag mode enabled
+    const mockUseMinesweeper = jest.requireMock('@/hooks/useMinesweeper')
+    mockUseMinesweeper.useMinesweeper = jest.fn(() => ({
+      gameState: {
+        cells: [],
+        width: 9,
+        height: 9,
+        mineCount: 10,
+        flaggedCount: 0,
+        revealedCount: 0,
+        gameStatus: 'playing',
+        isFirstClick: true,
+        isFlagMode: true,
+      },
+      difficulty: 'easy',
+      resetGame: jest.fn(),
+      toggleFlagMode: jest.fn(),
+      handleCellClick: jest.fn(),
+      handleCellRightClick: jest.fn(),
+    }))
+
+    render(<Minesweeper />)
+    
+    // 旗立モードのヒントが表示されることを確認
+    expect(screen.getByText('🚩 旗立モード: 左クリックでフラグを立てます')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 概要
ヒントテキスト「💡 ヒント: 数字は周囲の地雷の数を示しています」を削除しました。

## 変更内容
- ヒントテキストを削除してUIをシンプルに
- 旗立モードのヒントは残して必要な時のみ表示
- Minesweeperコンポーネントの包括的なテストを追加

## テスト
- ヒントテキストが表示されないことを確認するテスト
- 旗立モードのヒントが適切に表示されることを確認するテスト
- 全36個のテストが通過

## 技術的詳細
-  からヒントテキストを削除
-  を新規作成
- コンポーネントの動作を包括的にテスト

## 確認事項
- [x] 全てのテストが通過
- [x] TypeScriptエラーなし
- [x] ESLint警告のみ（既存の警告）
- [x] 既存機能に影響なし