### PR TITLE
Remove flag mode hint message

### DIFF
--- a/src/components/Minesweeper.tsx
+++ b/src/components/Minesweeper.tsx
@@ -64,9 +64,6 @@ export default function Minesweeper() {
           </div>
 
           <div className={styles.footer}>
-            {gameState.isFlagMode && (
-              <p className={styles.flagModeHint}>🚩 旗立モード: 左クリックでフラグを立てます</p>
-            )}
           </div>
         </div>
       </div>

--- a/src/components/__tests__/Minesweeper.test.tsx
+++ b/src/components/__tests__/Minesweeper.test.tsx
@@ -88,7 +88,7 @@ describe('Minesweeper Component', () => {
     expect(screen.queryByText('🚩 旗立モード: 左クリックでフラグを立てます')).not.toBeInTheDocument()
   })
 
-  it('renders flag mode hint when flag mode is enabled', () => {
+  it('does not render flag mode hint when flag mode is enabled', () => {
     // Mock the hook to return flag mode enabled
     const mockUseMinesweeper = jest.requireMock('@/hooks/useMinesweeper')
     mockUseMinesweeper.useMinesweeper = jest.fn(() => ({
@@ -112,7 +112,7 @@ describe('Minesweeper Component', () => {
 
     render(<Minesweeper />)
     
-    // 旗立モードのヒントが表示されることを確認
-    expect(screen.getByText('🚩 旗立モード: 左クリックでフラグを立てます')).toBeInTheDocument()
+    // 旗立モードのヒントが表示されないことを確認（削除されたため）
+    expect(screen.queryByText('🚩 旗立モード: 左クリックでフラグを立てます')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## 概要
旗立モードを有効にした時に表示されるメッセージ「🚩 旗立モード: 左クリックでフラグを立てます」を削除しました。

## 変更内容
- 旗立モードのヒントメッセージを削除
- UIをよりシンプルでクリーンに
- テストを更新してメッセージが表示されないことを確認

## テスト
- 旗立モード有効時もメッセージが表示されないことを確認するテスト
- 全36個のテストが通過

## 技術的詳細
-  から旗立モードのヒントメッセージを削除
-  のテストケースを更新
- 既存機能に影響なし

## 確認事項
- [x] 全てのテストが通過
- [x] TypeScriptエラーなし
- [x] ESLint警告のみ（既存の警告）
- [x] 既存機能に影響なし