### PR TITLE
Add keyboard shortcuts for game controls

### DIFF
--- a/src/components/Minesweeper.tsx
+++ b/src/components/Minesweeper.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect, useCallback } from 'react';
 import { useMinesweeper } from '@/hooks/useMinesweeper';
 import GameBoard from './GameBoard';
 import GameInfo from './GameInfo';
@@ -19,9 +20,40 @@ export default function Minesweeper() {
     resetGame(newDifficulty);
   };
 
-  const handleReset = () => {
+  const handleReset = useCallback(() => {
     resetGame();
-  };
+  }, [resetGame]);
+
+  // キーボードイベント処理
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      // フォーム要素やボタンがフォーカスされている場合は無視
+      if (event.target instanceof HTMLInputElement || 
+          event.target instanceof HTMLTextAreaElement || 
+          event.target instanceof HTMLButtonElement) {
+        return;
+      }
+
+      switch (event.key) {
+        case ' ':
+          // スペースキーでゲームリセット
+          event.preventDefault();
+          handleReset();
+          break;
+        case 'Tab':
+          // Tabキーで旗立モード切り替え
+          event.preventDefault();
+          toggleFlagMode();
+          break;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleReset, toggleFlagMode]);
 
   return (
     <div className={styles.container}>
@@ -64,6 +96,9 @@ export default function Minesweeper() {
           </div>
 
           <div className={styles.footer}>
+            <p className={styles.keyboardHints}>
+              キーボードショートカット: スペースキーでリセット、Tabキーで旗立モード切り替え
+            </p>
           </div>
         </div>
       </div>

--- a/src/components/__tests__/Minesweeper.test.tsx
+++ b/src/components/__tests__/Minesweeper.test.tsx
@@ -115,4 +115,74 @@ describe('Minesweeper Component', () => {
     // 旗立モードのヒントが表示されないことを確認（削除されたため）
     expect(screen.queryByText('🚩 旗立モード: 左クリックでフラグを立てます')).not.toBeInTheDocument()
   })
+
+  it('renders keyboard shortcuts hint', () => {
+    render(<Minesweeper />)
+    
+    expect(screen.getByText('キーボードショートカット: スペースキーでリセット、Tabキーで旗立モード切り替え')).toBeInTheDocument()
+  })
+
+  it('handles space key for game reset', () => {
+    const mockResetGame = jest.fn()
+    const mockUseMinesweeper = jest.requireMock('@/hooks/useMinesweeper')
+    mockUseMinesweeper.useMinesweeper = jest.fn(() => ({
+      gameState: {
+        cells: [],
+        width: 9,
+        height: 9,
+        mineCount: 10,
+        flaggedCount: 0,
+        revealedCount: 0,
+        gameStatus: 'playing',
+        isFirstClick: true,
+        isFlagMode: false,
+      },
+      difficulty: 'easy',
+      resetGame: mockResetGame,
+      toggleFlagMode: jest.fn(),
+      handleCellClick: jest.fn(),
+      handleCellRightClick: jest.fn(),
+    }))
+
+    render(<Minesweeper />)
+    
+    // スペースキーをシミュレート
+    const spaceEvent = new KeyboardEvent('keydown', { key: ' ' })
+    window.dispatchEvent(spaceEvent)
+    
+    expect(mockResetGame).toHaveBeenCalled()
+  })
+
+  it('handles tab key for flag mode toggle', () => {
+    const mockToggleFlagMode = jest.fn()
+    const mockUseMinesweeper = jest.requireMock('@/hooks/useMinesweeper')
+    mockUseMinesweeper.useMinesweeper = jest.fn(() => ({
+      gameState: {
+        cells: [],
+        width: 9,
+        height: 9,
+        mineCount: 10,
+        flaggedCount: 0,
+        revealedCount: 0,
+        gameStatus: 'playing',
+        isFirstClick: true,
+        isFlagMode: false,
+      },
+      difficulty: 'easy',
+      resetGame: jest.fn(),
+      toggleFlagMode: mockToggleFlagMode,
+      handleCellClick: jest.fn(),
+      handleCellRightClick: jest.fn(),
+    }))
+
+    render(<Minesweeper />)
+    
+    // Tabキーをシミュレート
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab' })
+    window.dispatchEvent(tabEvent)
+    
+    expect(mockToggleFlagMode).toHaveBeenCalled()
+  })
+
+
 })


### PR DESCRIPTION
## 概要
[Issue #6](https://github.com/kinzaru3/minesweeper-frontend/issues/6)の要望に基づいてキーボードショートカット機能を実装しました。

## 実装内容
- **スペースキー**: ゲームリセット
- **Tabキー**: 旗立モード切り替え
- **フォーカス制御**: フォーム要素がフォーカスされている場合はキーバインドを無効化
- **UI改善**: キーボードショートカットの説明を追加

## 技術的詳細
- を使用したキーボードイベント監視
- でパフォーマンス最適化
- フォーム要素のフォーカス状態を考慮した制御
- 包括的なテストケースを追加

## テスト
- キーボードショートカットの動作確認
- UI表示の確認
- 全39個のテストが通過

## 確認事項
- [x] 全てのテストが通過
- [x] TypeScriptエラーなし
- [x] ESLint警告のみ（既存の警告）
- [x] 既存機能に影響なし
- [x] Issue #6の要件を満たす

Closes #6