### PR TITLE
🔧 fix: Tabキーの不安定な動作を修正し、スペースキーのみに変更

### DIFF
--- a/src/components/Minesweeper.tsx
+++ b/src/components/Minesweeper.tsx
@@ -40,11 +40,6 @@ export default function Minesweeper() {
           event.preventDefault();
           handleReset();
           break;
-        case 'Tab':
-          // Tabキーで旗立モード切り替え
-          event.preventDefault();
-          toggleFlagMode();
-          break;
       }
     };
 
@@ -53,7 +48,7 @@ export default function Minesweeper() {
     return () => {
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [handleReset, toggleFlagMode]);
+  }, [handleReset]);
 
   return (
     <div className={styles.container}>
@@ -97,7 +92,7 @@ export default function Minesweeper() {
 
           <div className={styles.footer}>
             <p className={styles.keyboardHints}>
-              キーボードショートカット: スペースキーでリセット、Tabキーで旗立モード切り替え
+              キーボードショートカット: スペースキーでリセット
             </p>
           </div>
         </div>

--- a/src/components/__tests__/Minesweeper.test.tsx
+++ b/src/components/__tests__/Minesweeper.test.tsx
@@ -119,7 +119,7 @@ describe('Minesweeper Component', () => {
   it('renders keyboard shortcuts hint', () => {
     render(<Minesweeper />)
     
-    expect(screen.getByText('キーボードショートカット: スペースキーでリセット、Tabキーで旗立モード切り替え')).toBeInTheDocument()
+    expect(screen.getByText('キーボードショートカット: スペースキーでリセット')).toBeInTheDocument()
   })
 
   it('handles space key for game reset', () => {
@@ -153,7 +153,7 @@ describe('Minesweeper Component', () => {
     expect(mockResetGame).toHaveBeenCalled()
   })
 
-  it('handles tab key for flag mode toggle', () => {
+  it('does not handle tab key for flag mode toggle', () => {
     const mockToggleFlagMode = jest.fn()
     const mockUseMinesweeper = jest.requireMock('@/hooks/useMinesweeper')
     mockUseMinesweeper.useMinesweeper = jest.fn(() => ({
@@ -181,7 +181,8 @@ describe('Minesweeper Component', () => {
     const tabEvent = new KeyboardEvent('keydown', { key: 'Tab' })
     window.dispatchEvent(tabEvent)
     
-    expect(mockToggleFlagMode).toHaveBeenCalled()
+    // Tabキーは無効化されているため、toggleFlagModeは呼ばれない
+    expect(mockToggleFlagMode).not.toHaveBeenCalled()
   })
 
 


### PR DESCRIPTION
## 概要
[Issue #8](https://github.com/kinzaru3/minesweeper-frontend/issues/8)の要望に基づいて、Tabキーの不安定な動作を修正しました。

## 修正内容
- **Tabキー機能を削除**: 旗立モード切り替え機能を無効化
- **スペースキーのみに変更**: ゲームリセット機能のみを残す
- **UI更新**: キーボードショートカットの説明を更新
- **テスト更新**: Tabキーの動作を無効化するテストに変更

## 技術的詳細
- の依存関係からを削除
- キーボードイベント処理からTabキーのケースを削除
- UIの説明テキストを更新
- テストケースを修正してTabキーが無効化されることを確認

## テスト
- Tabキーが無効化されることを確認するテスト
- スペースキーは正常に動作することを確認
- 全39個のテストが通過

## 確認事項
- [x] 全てのテストが通過
- [x] TypeScriptエラーなし
- [x] ESLint警告のみ（既存の警告）
- [x] 既存機能に影響なし
- [x] Issue #8の要件を満たす

Closes #8