### PR TITLE
⚙️ config: ゲーム開始時のデフォルト状態を上級・旗立モード有効に変更

### DIFF
--- a/src/hooks/__tests__/useMinesweeper.test.ts
+++ b/src/hooks/__tests__/useMinesweeper.test.ts
@@ -12,7 +12,7 @@ import {
 
 // Mock the utils
 jest.mock('@/utils/minesweeper', () => ({
-  getDifficultyConfig: jest.fn(() => ({ width: 3, height: 3, mineCount: 2 })),
+  getDifficultyConfig: jest.fn(() => ({ width: 30, height: 16, mineCount: 99 })),
   createEmptyBoard: jest.fn(() => [
     [
       { id: '0-0', x: 0, y: 0, state: 'hidden', type: 'empty', mineCount: 0, isMine: false },
@@ -53,16 +53,16 @@ describe('useMinesweeper Hook', () => {
 
     expect(result.current.gameState).toEqual({
       cells: expect.any(Array),
-      width: 3,
-      height: 3,
-      mineCount: 2,
+      width: 30,
+      height: 16,
+      mineCount: 99,
       flaggedCount: 0,
       revealedCount: 0,
       gameStatus: 'playing',
       isFirstClick: true,
-      isFlagMode: false,
+      isFlagMode: true,
     })
-    expect(result.current.difficulty).toBe('easy')
+    expect(result.current.difficulty).toBe('hard')
   })
 
   it('resets game correctly', () => {
@@ -73,7 +73,7 @@ describe('useMinesweeper Hook', () => {
     })
 
     expect(result.current.gameState.isFirstClick).toBe(true)
-    expect(result.current.gameState.isFlagMode).toBe(false)
+    expect(result.current.gameState.isFlagMode).toBe(true)
   })
 
   it('resets game with new difficulty', () => {
@@ -89,12 +89,6 @@ describe('useMinesweeper Hook', () => {
   it('toggles flag mode correctly', () => {
     const { result } = renderHook(() => useMinesweeper())
 
-    expect(result.current.gameState.isFlagMode).toBe(false)
-
-    act(() => {
-      result.current.toggleFlagMode()
-    })
-
     expect(result.current.gameState.isFlagMode).toBe(true)
 
     act(() => {
@@ -102,10 +96,21 @@ describe('useMinesweeper Hook', () => {
     })
 
     expect(result.current.gameState.isFlagMode).toBe(false)
+
+    act(() => {
+      result.current.toggleFlagMode()
+    })
+
+    expect(result.current.gameState.isFlagMode).toBe(true)
   })
 
   it('handles cell click in normal mode', () => {
     const { result } = renderHook(() => useMinesweeper())
+
+    // Disable flag mode first
+    act(() => {
+      result.current.toggleFlagMode()
+    })
 
     act(() => {
       result.current.handleCellClick(0, 0)
@@ -118,11 +123,7 @@ describe('useMinesweeper Hook', () => {
   it('handles cell click in flag mode', () => {
     const { result } = renderHook(() => useMinesweeper())
 
-    // Enable flag mode
-    act(() => {
-      result.current.toggleFlagMode()
-    })
-
+    // Flag mode is already enabled by default
     act(() => {
       result.current.handleCellClick(0, 0)
     })
@@ -144,6 +145,11 @@ describe('useMinesweeper Hook', () => {
 
   it('does not handle clicks when game is not playing', () => {
     const { result } = renderHook(() => useMinesweeper())
+
+    // Disable flag mode first to test normal mode
+    act(() => {
+      result.current.toggleFlagMode()
+    })
 
     // Mock game status as 'won' for the next call
     ;(checkGameStatus as jest.Mock).mockReturnValueOnce('won')

--- a/src/hooks/useMinesweeper.ts
+++ b/src/hooks/useMinesweeper.ts
@@ -14,9 +14,9 @@ import {
 } from '@/utils/minesweeper';
 
 export function useMinesweeper() {
-  const [difficulty, setDifficulty] = useState<GameDifficulty>('easy');
+  const [difficulty, setDifficulty] = useState<GameDifficulty>('hard');
   const [gameState, setGameState] = useState<GameState>(() => {
-    const config = getDifficultyConfig('easy');
+    const config = getDifficultyConfig('hard');
     return {
       cells: createEmptyBoard(config.width, config.height),
       width: config.width,
@@ -26,7 +26,7 @@ export function useMinesweeper() {
       revealedCount: 0,
       gameStatus: 'playing',
       isFirstClick: true,
-      isFlagMode: false,
+      isFlagMode: true,
     };
   });
 
@@ -43,7 +43,7 @@ export function useMinesweeper() {
       revealedCount: 0,
       gameStatus: 'playing',
       isFirstClick: true,
-      isFlagMode: false,
+      isFlagMode: true,
     });
     
     if (newDifficulty) {


### PR DESCRIPTION
## 概要
[Issue #10](https://github.com/kinzaru3/minesweeper-frontend/issues/10)の要望に基づいて、ゲーム開始時のデフォルト状態を変更しました。

## 変更内容
- **難易度**: 初級（easy）→ 上級（hard）
- **旗立モード**: 無効 → 有効
- **ボードサイズ**: 9×9 → 30×16
- **地雷数**: 10個 → 99個

## 技術的詳細
- フックの初期状態を変更
- 関数でも旗立モードが有効になるように修正
- テストケースを新しいデフォルト状態に合わせて更新
- モック設定を上級難易度に合わせて調整

## テスト
- デフォルト状態の確認テスト
- 旗立モードの動作確認テスト
- 全39個のテストが通過

## 確認事項
- [x] 全てのテストが通過
- [x] TypeScriptエラーなし
- [x] ESLint警告のみ（既存の警告）
- [x] 既存機能に影響なし
- [x] Issue #10の要件を満たす

Closes #10