### PR TITLE
⚡ improve: 旗立モードでも最初のクリックは通常モードと同様にマスを開けるように変更

### DIFF
--- a/src/hooks/__tests__/useMinesweeper.test.ts
+++ b/src/hooks/__tests__/useMinesweeper.test.ts
@@ -120,17 +120,34 @@ describe('useMinesweeper Hook', () => {
     expect(revealCell).toHaveBeenCalled()
   })
 
-  it('handles cell click in flag mode', () => {
+  it('handles first cell click in flag mode (should open cell)', () => {
     const { result } = renderHook(() => useMinesweeper())
 
-    // Flag mode is already enabled by default
+    // Flag mode is enabled by default, but first click should open cell
     act(() => {
       result.current.handleCellClick(0, 0)
     })
 
+    expect(placeMines).toHaveBeenCalled()
+    expect(revealCell).toHaveBeenCalled()
+    expect(toggleFlag).not.toHaveBeenCalled()
+  })
+
+  it('handles second cell click in flag mode (should toggle flag)', () => {
+    const { result } = renderHook(() => useMinesweeper())
+
+    // First click should open cell
+    act(() => {
+      result.current.handleCellClick(0, 0)
+    })
+
+    // Second click should toggle flag
+    act(() => {
+      result.current.handleCellClick(1, 1)
+    })
+
     expect(toggleFlag).toHaveBeenCalled()
-    expect(placeMines).not.toHaveBeenCalled()
-    expect(revealCell).not.toHaveBeenCalled()
+    expect(placeMines).toHaveBeenCalledTimes(1) // Only called once for first click
   })
 
   it('handles cell right click', () => {

--- a/src/hooks/useMinesweeper.ts
+++ b/src/hooks/useMinesweeper.ts
@@ -64,24 +64,26 @@ export function useMinesweeper() {
     setGameState(prevState => {
       let newCells = [...prevState.cells];
 
-      // 旗立モードの場合、フラグを切り替える
-      if (prevState.isFlagMode) {
-        newCells = toggleFlag(newCells, x, y);
-        const stats = getGameStats(newCells);
-        return {
-          ...prevState,
-          cells: newCells,
-          flaggedCount: stats.flaggedCount,
-        };
-      }
-
-      // 最初のクリックの場合、地雷を配置
+      // 最初のクリックの場合、地雷を配置してセルを開く（旗立モードに関係なく）
       if (prevState.isFirstClick) {
         newCells = placeMines(newCells, prevState.mineCount, x, y);
+        newCells = revealCell(newCells, x, y);
+      } else {
+        // 2回目以降のクリックの場合
+        if (prevState.isFlagMode) {
+          // 旗立モードの場合、フラグを切り替える
+          newCells = toggleFlag(newCells, x, y);
+          const stats = getGameStats(newCells);
+          return {
+            ...prevState,
+            cells: newCells,
+            flaggedCount: stats.flaggedCount,
+          };
+        } else {
+          // 通常モードの場合、セルを開く
+          newCells = revealCell(newCells, x, y);
+        }
       }
-
-      // セルを開く
-      newCells = revealCell(newCells, x, y);
 
       // ゲーム状態をチェック
       const newGameStatus = checkGameStatus(newCells, prevState.mineCount);


### PR DESCRIPTION
## 概要
[Issue #11](https://github.com/kinzaru3/minesweeper-frontend/issues/11)の要望に基づいて、旗立モードの挙動を変更しました。

## 変更内容
- **最初のクリック**: 旗立モードでも通常モードと同様にマスを開ける
- **2回目以降のクリック**: 旗立モードではフラグを切り替える
- **ユーザビリティ向上**: より直感的な操作が可能に

## 技術的詳細
- 関数のロジックを変更
- 最初のクリックはフラグで判定
- 2回目以降はフラグで判定
- 地雷配置とセル開示の処理を最初のクリックに統合

## テスト
- 旗立モードでの最初のクリックがセルを開くことを確認
- 旗立モードでの2回目以降のクリックがフラグを切り替えることを確認
- 全40個のテストが通過

## 確認事項
- [x] 全てのテストが通過
- [x] TypeScriptエラーなし
- [x] ESLint警告のみ（既存の警告）
- [x] 既存機能に影響なし
- [x] Issue #11の要件を満たす

Closes #11