### PR TITLE
タイマー機能を実装 - Issue #12 を解決

### DIFF
--- a/src/components/GameInfo.module.scss
+++ b/src/components/GameInfo.module.scss
@@ -50,6 +50,11 @@
     font-size: 1.5rem;
     color: #60a5fa;
   }
+
+  &.timer {
+    font-size: 1.5rem;
+    color: #10b981;
+  }
 }
 
 .gameStatus {

--- a/src/components/GameInfo.tsx
+++ b/src/components/GameInfo.tsx
@@ -11,6 +11,7 @@ interface GameInfoProps {
   boardWidth: number;
   boardHeight: number;
   isFlagMode: boolean;
+  elapsedTime: number;
   onDifficultyChange: (difficulty: GameDifficulty) => void;
   onReset: () => void;
   onToggleFlagMode: () => void;
@@ -24,6 +25,7 @@ export default function GameInfo({
   boardWidth,
   boardHeight,
   isFlagMode,
+  elapsedTime,
   onDifficultyChange,
   onReset,
   onToggleFlagMode,
@@ -73,6 +75,13 @@ export default function GameInfo({
             <div className={styles.statLabel}>ボードサイズ</div>
             <div className={`${styles.statValue} ${styles.size}`}>
               {boardWidth}×{boardHeight}
+            </div>
+          </div>
+
+          <div className={styles.statItem}>
+            <div className={styles.statLabel}>経過時間</div>
+            <div className={`${styles.statValue} ${styles.timer}`}>
+              {Math.floor(elapsedTime / 60)}:{(elapsedTime % 60).toString().padStart(2, '0')}
             </div>
           </div>
         </div>

--- a/src/components/Minesweeper.tsx
+++ b/src/components/Minesweeper.tsx
@@ -10,6 +10,7 @@ export default function Minesweeper() {
   const {
     gameState,
     difficulty,
+    elapsedTime,
     resetGame,
     toggleFlagMode,
     handleCellClick,
@@ -71,6 +72,7 @@ export default function Minesweeper() {
             boardWidth={gameState.width}
             boardHeight={gameState.height}
             isFlagMode={gameState.isFlagMode}
+            elapsedTime={elapsedTime}
             onDifficultyChange={handleDifficultyChange}
             onReset={handleReset}
             onToggleFlagMode={toggleFlagMode}

--- a/src/components/__tests__/GameInfo.test.tsx
+++ b/src/components/__tests__/GameInfo.test.tsx
@@ -155,6 +155,25 @@ describe('GameInfo Component', () => {
     expect(statValueElement).toHaveClass('size')
   })
 
+  it('renders timer correctly', () => {
+    render(<GameInfo {...defaultProps} elapsedTime={65} />)
+
+    expect(screen.getByText('経過時間')).toBeInTheDocument()
+    expect(screen.getByText('1:05')).toBeInTheDocument()
+  })
+
+  it('renders timer with zero padding', () => {
+    render(<GameInfo {...defaultProps} elapsedTime={30} />)
+
+    expect(screen.getByText('0:30')).toBeInTheDocument()
+  })
+
+  it('renders timer with large values', () => {
+    render(<GameInfo {...defaultProps} elapsedTime={3661} />)
+
+    expect(screen.getByText('61:01')).toBeInTheDocument()
+  })
+
   it('renders different board sizes correctly', () => {
     const { rerender } = render(<GameInfo {...defaultProps} boardWidth={9} boardHeight={9} />)
     expect(screen.getByText('9×9')).toBeInTheDocument()

--- a/src/hooks/__tests__/useMinesweeper.test.ts
+++ b/src/hooks/__tests__/useMinesweeper.test.ts
@@ -184,4 +184,53 @@ describe('useMinesweeper Hook', () => {
     // The second click should not work because game status is 'won'
     expect(placeMines).toHaveBeenCalledTimes(1) // Only called once for first click
   })
+
+  it('initializes with timer state', () => {
+    const { result } = renderHook(() => useMinesweeper())
+
+    expect(result.current.elapsedTime).toBe(0)
+    expect(result.current.isTimerRunning).toBe(false)
+  })
+
+  it('starts timer on first click', () => {
+    const { result } = renderHook(() => useMinesweeper())
+
+    act(() => {
+      result.current.handleCellClick(0, 0)
+    })
+
+    expect(result.current.isTimerRunning).toBe(true)
+  })
+
+  it('stops timer when game ends', () => {
+    const { result } = renderHook(() => useMinesweeper())
+
+    // Mock game status as 'won' for the next call
+    ;(checkGameStatus as jest.Mock).mockReturnValueOnce('won')
+
+    act(() => {
+      result.current.handleCellClick(0, 0)
+    })
+
+    expect(result.current.isTimerRunning).toBe(false)
+  })
+
+  it('resets timer when game is reset', () => {
+    const { result } = renderHook(() => useMinesweeper())
+
+    // Start timer
+    act(() => {
+      result.current.handleCellClick(0, 0)
+    })
+
+    expect(result.current.isTimerRunning).toBe(true)
+
+    // Reset game
+    act(() => {
+      result.current.resetGame()
+    })
+
+    expect(result.current.elapsedTime).toBe(0)
+    expect(result.current.isTimerRunning).toBe(false)
+  })
 })


### PR DESCRIPTION
## 概要

このPRは[Issue #12](https://github.com/kinzaru3/minesweeper-frontend/issues/12)で要求されたタイマー機能を実装します。

## 実装内容

### タイマー機能
- ✅ ゲーム開始から終了までの経過時間を表示
- ✅ 最初のセルクリックでタイマー開始
- ✅ MM:SS形式での時間表示
- ✅ ゲーム終了時（勝利/敗北）にタイマー停止
- ✅ 新しいゲーム開始時にタイマーリセット
- ✅ メモリリーク防止のための適切なクリーンアップ

### 変更ファイル
-  - タイマーロジックの実装
-  - タイマー表示の実装
-  - タイマーのスタイリング
-  - タイマー状態の管理
- テストファイルの更新

## 動作確認
- [x] タイマーが正しく開始される
- [x] 時間が正しく表示される
- [x] ゲーム終了時にタイマーが停止する
- [x] 新しいゲームでタイマーがリセットされる

## 関連Issue
Closes #12